### PR TITLE
chore: Added rework of filters and split them out into separate files

### DIFF
--- a/__react/utils/bindings.js
+++ b/__react/utils/bindings.js
@@ -7,7 +7,7 @@
  */
 export function includeUnsubAfterForSubscription(message) {
   if (message.hasBinding('nats') && message.bindings().nats.unsubAfter) {
-    return `subscribeOptions.max = '${message.bindings().nats.unsubAfter}';`;
+    return `subscribeOptions.max = '${message.binding('nats').unsubAfter}';`;
   }
   return '';
 }

--- a/__react/utils/bindings.js
+++ b/__react/utils/bindings.js
@@ -40,8 +40,8 @@ export function isPubsub(channel) {
  * Is the channel a request and reply.
  */
 export function isRequestReply(channel) {
-  if (!channel.hasBinding('nats') ||
-      !channel.binding('nats').is || 
+  if (channel.hasBinding('nats') &&
+      channel.binding('nats').is && 
       channel.binding('nats').is === 'requestReply') {
     return true;
   }

--- a/__react/utils/bindings.js
+++ b/__react/utils/bindings.js
@@ -1,48 +1,48 @@
+
+
+/**
+ * Wrapper to include subscriptions option code if specified in the spec.
+ * 
+ * @param {*} message to check for queue bindings on 
+ */
 export function includeUnsubAfterForSubscription(message) {
-  if (hasNatsBindings(message) && message.bindings().nats().unsubAfter()) {
-    return `subscribeOptions.max = '${message.bindings().nats().unsubAfter()}';`;
-  }
-  return '';
-}
-export function includeQueueForSubscription(message) {
-  if (hasNatsBindings(message) && message.bindings().nats().queue()) {
-    return `subscribeOptions.queue = '${message.bindings().nats().queue()}';`;
+  if (message.hasBinding('nats') && message.bindings().nats.unsubAfter) {
+    return `subscribeOptions.max = '${message.bindings().nats.unsubAfter}';`;
   }
   return '';
 }
 
 /**
- * Does an object have bindings
+ * Wrapper to include subscriptions queue option if specified in the spec.
+ * 
+ * @param {*} message to check for queue bindings on 
  */
-export function hasNatsBindings(obj) {
-  return obj.bindings() && obj.bindings().nats();
+export function includeQueueForSubscription(message) {
+  if (message.hasBinding('nats') && message.binding('nats').queue) {
+    return `subscribeOptions.queue = '${message.binding('nats').queue}';`;
+  }
+  return '';
 }
-  
+
 /**
-   * is the channel a publish and subscribe type if nothing is specified default to being pubsub type 
-   */
+ * Is the channel a publish and subscribe. This is the default type if none is defined.
+ */
 export function isPubsub(channel) {
-  const tempChannel = channel._json;
-  if (
-    !tempChannel.bindings || 
-      !tempChannel.bindings.nats ||
-      !tempChannel.bindings.nats.is || 
-      tempChannel.bindings.nats.is === 'pubsub') {
+  if (!channel.hasBinding('nats') ||
+      !channel.binding('nats').is || 
+      channel.binding('nats').is === 'pubsub') {
     return true;
   }
   return false;
 }
   
 /**
- * is the channel a request and reply
+ * Is the channel a request and reply.
  */
 export function isRequestReply(channel) {
-  const tempChannel = channel._json;
-  if (
-    tempChannel.bindings &&
-      tempChannel.bindings.nats &&
-      tempChannel.bindings.nats.is === 'requestReply'
-  ) {
+  if (!channel.hasBinding('nats') ||
+      !channel.binding('nats').is || 
+      channel.binding('nats').is === 'requestReply') {
     return true;
   }
   return false;
@@ -52,12 +52,9 @@ export function isRequestReply(channel) {
  * Is the request reply a requester
  */
 export function isRequester(channel) {
-  const tempChannel = channel._json;
-  if (
-    isRequestReply(channel) &&
-      tempChannel.bindings.nats.requestReply &&
-      tempChannel.bindings.nats.requestReply.is === 'requester'
-  ) {
+  if (isRequestReply(channel) &&
+      channel.binding('nats').requestReply &&
+      channel.binding('nats').requestReply.is === 'requester') {
     return true;
   }
   return false;
@@ -67,12 +64,9 @@ export function isRequester(channel) {
  * Is the request reply a replier
  */
 export function isReplier(channel) {
-  const tempChannel = channel._json;
-  if (
-    isRequestReply(channel) &&
-      tempChannel.bindings.nats.requestReply &&
-      tempChannel.bindings.nats.requestReply.is === 'replier'
-  ) {
+  if (isRequestReply(channel) &&
+      channel.binding('nats').requestReply &&
+      channel.binding('nats').requestReply.is === 'replier') {
     return true;
   }
   return false;

--- a/__react/utils/bindings.js
+++ b/__react/utils/bindings.js
@@ -34,8 +34,8 @@ export function isPubsub(channel) {
 }
   
 /**
-   * is the channel a request and reply
-   */
+ * is the channel a request and reply
+ */
 export function isRequestReply(channel) {
   const tempChannel = channel._json;
   if (
@@ -49,8 +49,8 @@ export function isRequestReply(channel) {
 }
   
 /**
-   * Is the request reply a requester
-   */
+ * Is the request reply a requester
+ */
 export function isRequester(channel) {
   const tempChannel = channel._json;
   if (
@@ -64,8 +64,8 @@ export function isRequester(channel) {
 }
   
 /**
-   * Is the request reply a replier
-   */
+ * Is the request reply a replier
+ */
 export function isReplier(channel) {
   const tempChannel = channel._json;
   if (

--- a/__react/utils/bindings.js
+++ b/__react/utils/bindings.js
@@ -15,7 +15,7 @@ export function includeQueueForSubscription(message) {
  * Does an object have bindings
  */
 export function hasNatsBindings(obj) {
-  return obj.bindings && obj.bindings.nats;
+  return obj.bindings() && obj.bindings().nats();
 }
   
 /**

--- a/__react/utils/bindings.js
+++ b/__react/utils/bindings.js
@@ -1,0 +1,79 @@
+export function includeUnsubAfterForSubscription(message) {
+  if (hasNatsBindings(message) && message.bindings().nats().unsubAfter()) {
+    return `subscribeOptions.max = '${message.bindings().nats().unsubAfter()}';`;
+  }
+  return '';
+}
+export function includeQueueForSubscription(message) {
+  if (hasNatsBindings(message) && message.bindings().nats().queue()) {
+    return `subscribeOptions.queue = '${message.bindings().nats().queue()}';`;
+  }
+  return '';
+}
+
+/**
+ * Does an object have bindings
+ */
+export function hasNatsBindings(obj) {
+  return obj.bindings && obj.bindings.nats;
+}
+  
+/**
+   * is the channel a publish and subscribe type if nothing is specified default to being pubsub type 
+   */
+export function isPubsub(channel) {
+  const tempChannel = channel._json;
+  if (
+    !tempChannel.bindings || 
+      !tempChannel.bindings.nats ||
+      !tempChannel.bindings.nats.is || 
+      tempChannel.bindings.nats.is === 'pubsub') {
+    return true;
+  }
+  return false;
+}
+  
+/**
+   * is the channel a request and reply
+   */
+export function isRequestReply(channel) {
+  const tempChannel = channel._json;
+  if (
+    tempChannel.bindings &&
+      tempChannel.bindings.nats &&
+      tempChannel.bindings.nats.is === 'requestReply'
+  ) {
+    return true;
+  }
+  return false;
+}
+  
+/**
+   * Is the request reply a requester
+   */
+export function isRequester(channel) {
+  const tempChannel = channel._json;
+  if (
+    isRequestReply(channel) &&
+      tempChannel.bindings.nats.requestReply &&
+      tempChannel.bindings.nats.requestReply.is === 'requester'
+  ) {
+    return true;
+  }
+  return false;
+}
+  
+/**
+   * Is the request reply a replier
+   */
+export function isReplier(channel) {
+  const tempChannel = channel._json;
+  if (
+    isRequestReply(channel) &&
+      tempChannel.bindings.nats.requestReply &&
+      tempChannel.bindings.nats.requestReply.is === 'replier'
+  ) {
+    return true;
+  }
+  return false;
+}

--- a/__react/utils/channelname.js
+++ b/__react/utils/channelname.js
@@ -11,6 +11,10 @@ export function realizeChannelName(parameters, channelName) {
   return returnString;
 }
   
+/**
+ * Realize channel name to NATS topic without replacing parameters
+ * @param {*} channelName 
+ */
 export function realizeChannelNameWithoutParameters(channelName) {
   return realizeChannelName(null, channelName);
 }

--- a/__react/utils/channelname.js
+++ b/__react/utils/channelname.js
@@ -1,0 +1,17 @@
+
+/**
+ * Convert RFC 6570 URI with parameters to NATS topic. 
+ */
+export function realizeChannelName(parameters, channelName) {
+  let returnString = `\`${  channelName  }\``;
+  returnString = returnString.replace(/\//g, '.');
+  for (const paramName in parameters) {
+    returnString = returnString.replace(`{${paramName}}`, `\${${paramName}}`);
+  }
+  return returnString;
+}
+  
+export function realizeChannelNameWithoutParameters(channelName) {
+  return realizeChannelName(null, channelName);
+}
+  

--- a/__react/utils/general.js
+++ b/__react/utils/general.js
@@ -1,0 +1,166 @@
+import _ from 'lodash';
+export function shouldPromisfyCallbacks(params) {
+  return params.promisifyReplyCallback;
+}
+
+export function camelCase(string) {
+  return _.camelCase(string);
+}
+export function pascalCase(string) {
+  string = _.camelCase(string);
+  return string.charAt(0).toUpperCase() + string.slice(1);
+}
+export function kebabCase(string) {
+  return _.kebabCase(string);
+}
+
+/**
+ * Figure out if our message content type or default content type matches a given payload.
+ * @param {*} messageContentType to check
+ * @param {*} defaultContentType to check
+ * @param {*} payload to find
+ */
+function containsPayload(messageContentType, defaultContentType, payload) {
+  if (
+    (messageContentType !== undefined &&
+      messageContentType.toLowerCase() === payload) ||
+    (defaultContentType !== undefined && defaultContentType === payload)
+  ) {
+    return true;
+  }
+  return false;
+}
+export function isBinaryPayload (messageContentType, defaultContentType) {
+  return containsPayload(messageContentType, defaultContentType, 'binary');
+}
+export function isStringPayload(messageContentType, defaultContentType) {
+  return containsPayload(messageContentType, defaultContentType, 'string');
+}
+export function isJsonPayload(messageContentType, defaultContentType) {
+  return containsPayload(messageContentType, defaultContentType, 'json');
+}
+
+export function getClientToUse(message, defaultContentType) {
+  if (isBinaryPayload(message.contentType(), defaultContentType)) {
+    return 'const nc: Client = this.binaryClient!;';
+  } else if (isStringPayload(message.contentType(), defaultContentType)) {
+    return 'const nc: Client = this.stringClient!;';
+  } else if (isJsonPayload(message.contentType(), defaultContentType)) {
+    return 'const nc: Client = this.jsonClient!;';
+  } 
+  //Default to JSON client
+  return 'const nc: Client = this.jsonClient!;';
+}
+
+export function messageHasNotNullPayload(messagePayload) {
+  return `${messagePayload.type()}` !== 'null';
+}
+
+/**
+ * Because quicktype cant handle null types we have to ensure if it is null thats 
+ */
+export function getMessageType(message) {
+  if (`${message.payload().type()}` === 'null') {
+    return 'null';
+  }
+  return `${pascalCase(message.uid())}Message.${pascalCase(message.uid())}`;
+}
+
+/**
+ * Figure out if a content type is located in the document.
+ * @param {*} document to look through
+ * @param {*} payload to find
+ */
+function containsPayloadInDocument(document, payload) {
+  if (
+    document.defaultContentType() !== undefined &&
+    document.defaultContentType().toLowerCase() === payload
+  ) {
+    return true;
+  }
+  const channels = document.channels();
+  if (channels !== undefined) {
+    for (const key in document.channels()) {
+      if (Object.hasOwnProperty.call(document.channels(), key)) {
+        const channel = document.channels()[`${key}`];
+        if (
+          (channel.hasPublish() &&
+            channel
+              .publish()
+              .message()
+              .contentType() !== undefined &&
+            channel
+              .publish()
+              .message()
+              .contentType()
+              .toLowerCase() === payload) ||
+          (channel.hasSubscribe() &&
+            channel
+              .subscribe()
+              .message()
+              .contentType() !== undefined &&
+            channel
+              .subscribe()
+              .message()
+              .contentType()
+              .toLowerCase() === payload)
+        ) {
+          return true;
+        }
+      }
+    }
+  }
+  return false;
+}
+export function containsBinaryPayload(document) {
+  return containsPayloadInDocument(document, 'binary');
+}
+export function containsStringPayload(document) {
+  return containsPayloadInDocument(document, 'string');
+}
+export function containsJsonPayload(document) {
+  return containsPayloadInDocument(document, 'json');
+}
+
+/**
+ * Convert JSON schema draft 7 types to typescript types 
+ * @param {*} jsonSchemaType 
+ * @param {*} property 
+ */
+export function toTsType(jsonSchemaType, property) {
+  switch (jsonSchemaType.toLowerCase()) {
+  case 'string':
+    return 'string';
+  case 'integer':
+  case 'number':
+    return 'Number';
+  case 'boolean':
+    return 'Boolean';
+  case 'object':
+    if (property) {
+      return `${property.uid()  }Schema`;
+    }
+    return 'any';
+      
+  default: return 'any';
+  }
+}
+
+/**
+ * Cast JSON schema variable to typescript type
+ * 
+ * @param {*} jsonSchemaType 
+ * @param {*} variableToCast 
+ */
+export function castToTsType(jsonSchemaType, variableToCast) {
+  switch (jsonSchemaType.toLowerCase()) {
+  case 'string':
+    return `"" + ${variableToCast}`;
+  case 'integer':
+  case 'number':
+    return `Number(${variableToCast})`;
+  case 'boolean':
+    return `Boolean(${variableToCast})`;
+  default: throw new Error(`Parameter type not supported - ${  jsonSchemaType}`);
+  }
+}

--- a/__react/utils/general.js
+++ b/__react/utils/general.js
@@ -1,7 +1,15 @@
 import _ from 'lodash';
-export function shouldPromisfyCallbacks(params) {
+
+/**
+ * Should the callbacks be promisified.
+ * 
+ * @param {*} params passed to the template
+ * @returns {boolean} should it promisify callbacks
+ */
+export function shouldPromisifyCallbacks(params) {
   return params.promisifyReplyCallback;
 }
+
 
 export function camelCase(string) {
   return _.camelCase(string);
@@ -16,6 +24,7 @@ export function kebabCase(string) {
 
 /**
  * Figure out if our message content type or default content type matches a given payload.
+ * 
  * @param {*} messageContentType to check
  * @param {*} defaultContentType to check
  * @param {*} payload to find
@@ -40,6 +49,12 @@ export function isJsonPayload(messageContentType, defaultContentType) {
   return containsPayload(messageContentType, defaultContentType, 'json');
 }
 
+/**
+ * Based on the payload type of the message choose a client
+ * 
+ * @param {*} message 
+ * @param {*} defaultContentType 
+ */
 export function getClientToUse(message, defaultContentType) {
   if (isBinaryPayload(message.contentType(), defaultContentType)) {
     return 'const nc: Client = this.binaryClient!;';
@@ -52,12 +67,20 @@ export function getClientToUse(message, defaultContentType) {
   return 'const nc: Client = this.jsonClient!;';
 }
 
+/**
+ * Checks if the message payload is of type null
+ * 
+ * @param {*} messagePayload to check
+ * @returns {boolean} does the payload contain null type 
+ */
 export function messageHasNotNullPayload(messagePayload) {
   return `${messagePayload.type()}` !== 'null';
 }
 
 /**
- * Because quicktype cant handle null types we have to ensure if it is null thats 
+ * Because quicktype cant handle null types we have to ensure that the correct message type is returned.
+ * 
+ * @param {*} message to find the message type for
  */
 export function getMessageType(message) {
   if (`${message.payload().type()}` === 'null') {
@@ -68,6 +91,7 @@ export function getMessageType(message) {
 
 /**
  * Figure out if a content type is located in the document.
+ * 
  * @param {*} document to look through
  * @param {*} payload to find
  */
@@ -124,6 +148,7 @@ export function containsJsonPayload(document) {
 
 /**
  * Convert JSON schema draft 7 types to typescript types 
+ * 
  * @param {*} jsonSchemaType 
  * @param {*} property 
  */
@@ -138,7 +163,7 @@ export function toTsType(jsonSchemaType, property) {
     return 'Boolean';
   case 'object':
     if (property) {
-      return `${property.uid()  }Schema`;
+      return `${property.uid()}Schema`;
     }
     return 'any';
       

--- a/__react/utils/index.js
+++ b/__react/utils/index.js
@@ -1,0 +1,11 @@
+import { camelCase, pascalCase, kebabCase, isBinaryPayload, isStringPayload, isJsonPayload, messageHasNotNullPayload, getMessageType, containsBinaryPayload, containsStringPayload, containsJsonPayload, toTsType, castToTsType, getClientToUse, shouldPromisfyCallbacks} from './general';
+export { camelCase, pascalCase, kebabCase, isBinaryPayload, isStringPayload, isJsonPayload, messageHasNotNullPayload, getMessageType, containsBinaryPayload, containsStringPayload, containsJsonPayload, toTsType, castToTsType, getClientToUse, shouldPromisfyCallbacks};
+
+import { hasNatsBindings, isPubsub, isRequester, isRequestReply, isReplier, includeQueueForSubscription, includeUnsubAfterForSubscription } from './bindings';
+export { hasNatsBindings, isPubsub, isRequester, isRequestReply, isReplier, includeQueueForSubscription, includeUnsubAfterForSubscription };
+
+import { realizeChannelNameWithoutParameters, realizeChannelName } from './channelname';
+export { realizeChannelNameWithoutParameters, realizeChannelName };
+
+import { realizeParametersForChannelWithoutType, realizeParametersForChannelWrapper, realizeParametersForChannel, realizeParameterForChannelWithoutType } from './parameters';
+export { realizeParametersForChannelWithoutType, realizeParametersForChannelWrapper, realizeParametersForChannel, realizeParameterForChannelWithoutType };

--- a/__react/utils/parameters.js
+++ b/__react/utils/parameters.js
@@ -1,11 +1,12 @@
 import { toTsType } from './general';
+
 /**
  * Realize parameters without using types and without trailing comma
  */
 export function realizeParametersForChannelWithoutType(parameters) {
   let returnString = '';
   for (const paramName in parameters) {
-    returnString += `${realizeParameterForChannelWithoutType(paramName)},`;
+    returnString += `${paramName},`;
   }
   if (returnString.length >= 1) {
     returnString = returnString.slice(0, -1);
@@ -13,17 +14,25 @@ export function realizeParametersForChannelWithoutType(parameters) {
   return returnString;
 }
   
+/**
+ * Realize parameters for channels for function definitions in typescript
+ * 
+ * @param {*} channelParameters parameters to realize
+ * @param {*} required optional or required
+ */
 export function realizeParametersForChannelWrapper(channelParameters, required = true) {
   return Object.keys(channelParameters).length ? `,${realizeParametersForChannel(channelParameters, required)}` : '';
 }
-  
+
 /**
- * Realize parameters using types without trailing comma
- */
-export function realizeParametersForChannel(parameters, required = true) {
+  * Realize parameters using types without trailing comma
+  * @param {*} channelParameters parameters to realize
+  * @param {*} required optional or required
+  */
+export function realizeParametersForChannel(channelParameters, required = true) {
   let returnString = '';
-  for (const paramName in parameters) {
-    returnString += `${realizeParameterForChannelWithType(paramName, parameters[`${paramName}`], required)  },`;
+  for (const paramName in channelParameters) {
+    returnString += `${realizeParameterForChannelWithType(paramName, channelParameters[`${paramName}`], required)  },`;
   }
   if (returnString.length >= 1) {
     returnString = returnString.slice(0, -1);
@@ -31,9 +40,13 @@ export function realizeParametersForChannel(parameters, required = true) {
   return returnString;
 }
 
-export function realizeParameterForChannelWithoutType(parameterName) {
-  return `${parameterName}`;
-}
+/**
+ * Realize a single parameter with its type 
+ * 
+ * @param {*} parameterName parameter name to use as
+ * @param {*} parameter which contains the schema 
+ * @param {*} required should it be optional or required
+ */
 function realizeParameterForChannelWithType(parameterName, parameter, required = true) {
   const requiredType = !required ? '?' : '';
   return `${parameterName}${requiredType}: ${toTsType(

--- a/__react/utils/parameters.js
+++ b/__react/utils/parameters.js
@@ -18,8 +18,8 @@ export function realizeParametersForChannelWrapper(channelParameters, required =
 }
   
 /**
-   * Realize parameters using types without trailing comma
-   */
+ * Realize parameters using types without trailing comma
+ */
 export function realizeParametersForChannel(parameters, required = true) {
   let returnString = '';
   for (const paramName in parameters) {

--- a/__react/utils/parameters.js
+++ b/__react/utils/parameters.js
@@ -1,0 +1,42 @@
+import { toTsType } from './general';
+/**
+ * Realize parameters without using types and without trailing comma
+ */
+export function realizeParametersForChannelWithoutType(parameters) {
+  let returnString = '';
+  for (const paramName in parameters) {
+    returnString += `${realizeParameterForChannelWithoutType(paramName)},`;
+  }
+  if (returnString.length >= 1) {
+    returnString = returnString.slice(0, -1);
+  }
+  return returnString;
+}
+  
+export function realizeParametersForChannelWrapper(channelParameters, required = true) {
+  return Object.keys(channelParameters).length ? `,${realizeParametersForChannel(channelParameters, required)}` : '';
+}
+  
+/**
+   * Realize parameters using types without trailing comma
+   */
+export function realizeParametersForChannel(parameters, required = true) {
+  let returnString = '';
+  for (const paramName in parameters) {
+    returnString += `${realizeParameterForChannelWithType(paramName, parameters[`${paramName}`], required)  },`;
+  }
+  if (returnString.length >= 1) {
+    returnString = returnString.slice(0, -1);
+  }
+  return returnString;
+}
+
+export function realizeParameterForChannelWithoutType(parameterName) {
+  return `${parameterName}`;
+}
+function realizeParameterForChannelWithType(parameterName, parameter, required = true) {
+  const requiredType = !required ? '?' : '';
+  return `${parameterName}${requiredType}: ${toTsType(
+    parameter.schema().type()
+  )}`;
+}


### PR DESCRIPTION
**Description**
This PR introduces a refactoring of the filters for better maintainability. It introduces 5 utility files which are somewhat copy/paste with a little rewrite to ES6:

- `bindings` - contains all the binding support functions used for NATS.
- `channelname` - contains the functions for realizing the channel name based on provided parameters.
- `general` -  contains the general support functions for typescript
- `index` - wrapper which exports all the functions
- `parameters` - contains the functions for realizing the parameters to a function in the template.
