### PR TITLE
fix: default correctly to JSON client and use correct content types

### DIFF
--- a/docs/general.md
+++ b/docs/general.md
@@ -15,9 +15,9 @@ The test client is like a mirror client. It does everything the opposite, when y
 ## Supported Content Types
 The following payload types are supported, this is limited to the underlying NATS TypeScript library:
 
-* For binary payloads use: `binary` content type
-* For json payloads use: `json` content type
-* For string payloads use: `string` content type
+* For binary payloads use: `application/octet-stream` content type
+* For JSON payloads use: `application/json` content type, this is default if nothing is specified
+* For string payloads use: `text/plain` content type
 
 ## Client Hooks
 Sometimes to you want to change the data before sending or receiving it. For this purpose hooks has been added to control the flow of information outside the generated code. 

--- a/utils/general.js
+++ b/utils/general.js
@@ -2,6 +2,9 @@ import _ from 'lodash';
 const {FormatHelpers} = require('@asyncapi/generator-model-sdk');
 // eslint-disable-next-line no-unused-vars
 import { Message, Schema, AsyncAPIDocument} from '@asyncapi/parser';
+const contentTypeJSON = 'application/json';
+const contentTypeString = 'text/plain';
+const contentTypeBinary = 'application/octet-stream';
 
 /**
  * @typedef TemplateParameters
@@ -59,13 +62,13 @@ function containsPayload(messageContentType, defaultContentType, payload) {
   return false;
 }
 export function isBinaryPayload (messageContentType, defaultContentType) {
-  return containsPayload(messageContentType, defaultContentType, 'binary');
+  return containsPayload(messageContentType, defaultContentType, contentTypeBinary);
 }
 export function isStringPayload(messageContentType, defaultContentType) {
-  return containsPayload(messageContentType, defaultContentType, 'string');
+  return containsPayload(messageContentType, defaultContentType, contentTypeString);
 }
 export function isJsonPayload(messageContentType, defaultContentType) {
-  return containsPayload(messageContentType, defaultContentType, 'json');
+  return containsPayload(messageContentType, defaultContentType, contentTypeJSON);
 }
 
 /**
@@ -79,9 +82,7 @@ export function getClientToUse(message, defaultContentType) {
     return 'const nc: Client = this.binaryClient!;';
   } else if (isStringPayload(message.contentType(), defaultContentType)) {
     return 'const nc: Client = this.stringClient!;';
-  } else if (isJsonPayload(message.contentType(), defaultContentType)) {
-    return 'const nc: Client = this.jsonClient!;';
-  } 
+  }
   //Default to JSON client
   return 'const nc: Client = this.jsonClient!;';
 }
@@ -116,7 +117,7 @@ export function getMessageType(message) {
  */
 function containsPayloadInDocument(document, payload) {
   if (
-    document.defaultContentType() !== undefined &&
+    document.hasDefaultContentType() &&
     document.defaultContentType().toLowerCase() === payload
   ) {
     return true;
@@ -156,13 +157,15 @@ function containsPayloadInDocument(document, payload) {
   return false;
 }
 export function containsBinaryPayload(document) {
-  return containsPayloadInDocument(document, 'binary');
+  return containsPayloadInDocument(document, contentTypeBinary);
 }
 export function containsStringPayload(document) {
-  return containsPayloadInDocument(document, 'string');
+  return containsPayloadInDocument(document, contentTypeString);
 }
 export function containsJsonPayload(document) {
-  return containsPayloadInDocument(document, 'json');
+  const containsJsonPayload = containsPayloadInDocument(document, contentTypeJSON);
+  //Default to JSON type
+  return containsJsonPayload || (!containsBinaryPayload(document) && !containsStringPayload(document));
 }
 
 /**


### PR DESCRIPTION
**Description**
Currently, the template does not default correctly to the JSON client and the content types are checked incorrectly.
