### PR TITLE
fix: use specific model generation version

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
 	},
 	"dependencies": {
 		"@asyncapi/generator-filters": "^1.1.0",
-		"@asyncapi/generator-model-sdk": "^0.6.3",
+		"@asyncapi/generator-model-sdk": "0.6.4",
 		"@asyncapi/generator-react-sdk": "^0.2.6",
 		"@asyncapi/parser": "^1.5.0",
 		"cross-env": "^7.0.2",

--- a/template/src/schemas/schema.ts.js
+++ b/template/src/schemas/schema.ts.js
@@ -31,7 +31,7 @@ export default async function schemaRender({ asyncapi }) {
   for (const generatedModel of generatedModels) {
     const modelFileName = `${FormatHelpers.toPascalCase(generatedModel.modelName)}.ts`;
     const fileContent = `
-${generatedModel.model.getImmediateDependencies().map((value) => {return FormatHelpers.toPascalCase(value);}).join('\n')}
+${generatedModel.model.getNearestDependencies().map((value) => {return FormatHelpers.toPascalCase(value);}).join('\n')}
 ${generatedModel.result}
     `;
     files.push(<File name={modelFileName}>{fileContent}</File>);


### PR DESCRIPTION
**Description**
Since the model generation library might push breaking changes, lets not use the latest version automatically.