### PR TITLE
chore: switch to async generation for examples

### DIFF
--- a/scripts/generate-examples.js
+++ b/scripts/generate-examples.js
@@ -8,19 +8,21 @@
 const fs = require('fs');
 const path = require('path');
 const examplePath = path.resolve(__dirname, '..', 'examples');
+const util = require('util');
 // eslint-disable-next-line security/detect-child-process
-const {execSync} = require('child_process');
-
+const exec = util.promisify(require('child_process').exec);
+ 
 // 'linux' on Linux
 // 'win32' on Windows (32-bit / 64-bit)
 // 'darwin' on OSX
 const os = require('os');
+const { exit } = require('process');
 const platform = os.platform();
-
-fs.readdirSync(examplePath)
-  .map((file) => {return path.resolve(examplePath, file);})
-  .filter((exampleDir) => {return fs.lstatSync(exampleDir).isDirectory();})
-  .forEach((exampleDir) => {
+ 
+const promises = fs.readdirSync(examplePath)
+  .map((file) => { return path.resolve(examplePath, file); })
+  .filter((exampleDir) => { return fs.lstatSync(exampleDir).isDirectory(); })
+  .map((exampleDir) => {
     let command = 'generate:client';
     if (platform === 'win32') {
       command += ':windows';
@@ -32,5 +34,9 @@ fs.readdirSync(examplePath)
         force: true
       });
     }
-    execSync(`cd ${exampleDir} && npm run ${command} && npm i`, {stdio: 'inherit', timeout: 1000*60*5});
+    return exec(`cd ${exampleDir} && npm run ${command} && npm i`);
   });
+Promise.all(promises).catch((err) => {
+  console.error(err);
+  exit(1);
+});


### PR DESCRIPTION
**Description**
This PR fixes a problem where the generation timeout for https://github.com/asyncapi/ts-nats-template/pull/485 and https://github.com/asyncapi/ts-nats-template/pull/484