### PR TITLE
fix: test not working with multiple parameter

### DIFF
--- a/components/test/general.js
+++ b/components/test/general.js
@@ -10,8 +10,8 @@ import { ChannelParameter } from '@asyncapi/parser';
  */
 export function getReceivedVariableDeclaration(channelParameters) {
   return Object.entries(channelParameters).map(([paramName, param]) => {
-    return `var received${pascalCase(paramName)} : ${toTsType(param.schema().type())} | undefined = undefined`;
-  }).join('');
+    return `var received${pascalCase(paramName)} : ${toTsType(param.schema().type())} | undefined = undefined;`;
+  }).join('\n');
 }
 
 /**
@@ -21,8 +21,8 @@ export function getReceivedVariableDeclaration(channelParameters) {
  */
 export function getExampleParameters(channelParameters) {
   return Object.entries(channelParameters).map(([paramName, param]) => {
-    return `var ${pascalCase(paramName)}ToSend: ${toTsType(param.schema().type())} = ${generateExample(param.schema().json())}`;
-  }).join('');
+    return `var ${pascalCase(paramName)}ToSend: ${toTsType(param.schema().type())} = ${generateExample(param.schema().json())};`;
+  }).join('\n');
 }
 
 /**
@@ -42,8 +42,8 @@ export function getFunctionParameters(channelParameters) {
  */
 export function getSetReceivedParameters(channelParameters) {
   return Object.entries(channelParameters).map(([paramName, _]) => {
-    return `received${pascalCase(paramName)} = ${paramName}`;
-  }).join('');
+    return `received${pascalCase(paramName)} = ${paramName};`;
+  }).join('\n');
 }
 
 /**
@@ -53,7 +53,7 @@ export function getSetReceivedParameters(channelParameters) {
 export function getVerifyExpectedParameters(channelParameters) {
   return Object.entries(channelParameters).map(([paramName, _]) => {
     return `expect(received${pascalCase(paramName)}).to.be.equal(${pascalCase(paramName)}ToSend);`;
-  }).join('');
+  }).join('\n');
 }
 
 /**


### PR DESCRIPTION
**Description**
This PR fixes that channel tests are not working if there are multiple parameters.

Old code:
```ts
import {
  describe,
  it,
  before
} from 'mocha';
import {
  expect
} from 'chai';
import * as Client from '../../src'
import * as TestClient from '../../src/testclient'
import {
  NatsTypescriptTemplateError
} from '../../src/NatsTypescriptTemplateError';
describe('v0/rust/servers/{server_id}/events/player/{steam_id}/chatted can talk to itself', () => {
  var client: Client.NatsAsyncApiClient;
  var testClient: TestClient.NatsAsyncApiTestClient;
  before(async () => {
    client = new Client.NatsAsyncApiClient();
    testClient = new TestClient.NatsAsyncApiTestClient();
    const natsHost = process.env.NATS_HOST || "0.0.0.0"
    const natsPort = process.env.NATS_PORT || "4222"
    const natsUrl = `${natsHost}:${natsPort}`
    await client.connectToHost(natsUrl);
    await testClient.connectToHost(natsUrl);
  });
  it('can send message', async () => {
    var receivedError: NatsTypescriptTemplateError | undefined = undefined;
    var receivedMsg: Client.ChatMessage | undefined = undefined;
    var receivedServerId: string | undefined = undefinedvar receivedSteamId: string | undefined = undefined
    var publishMessage: TestClient.ChatMessage = TestClient.ChatMessage.unmarshal({
      "steam_id": "string",
      "player_name": "string",
      "raw_message": "string",
      "full_message": "string",
      "is_admin": true,
      "rank": 0,
      "title": "string",
      "timestamp": "2016-08-29T09:12:33.001Z"
    });
    var ServerIdToSend: string = "string"
    var SteamIdToSend: string = "string"
    const subscription = await client.subscribeToV0RustServersServerIdEventsPlayerSteamIdChatted((err, msg, server_id, steam_id) => {
        receivedError = err;
        receivedMsg = msg;
        receivedServerId = server_idreceivedSteamId = steam_id
      }, ServerIdToSend, SteamIdToSend,
      true
    );
    const tryAndWaitForResponse = new Promise((resolve, reject) => {
      let isReturned = false;
      setTimeout(() => {
        if (!isReturned) {
          reject(new Error("Timeout"));
        }
      }, 3000)
      setInterval(async () => {
        if (subscription.getReceived() === 1) {
          resolve(undefined);
          isReturned = true
        }
      }, 100);
    });
    await testClient.publishToV0RustServersServerIdEventsPlayerSteamIdChatted(publishMessage, ServerIdToSend, SteamIdToSend);
    await tryAndWaitForResponse;
    expect(receivedError).to.be.undefined;
    expect(receivedMsg).to.not.be.undefined;
    expect(receivedMsg!.marshal()).to.equal(publishMessage.marshal());
    expect(receivedServerId).to.be.equal(ServerIdToSend);
    expect(receivedSteamId).to.be.equal(SteamIdToSend);
  });
  after(async () => {
    await client.disconnect();
    await testClient.disconnect();
  });
});
```

New code:
```ts
import {
  describe,
  it,
  before
} from 'mocha';
import {
  expect
} from 'chai';
import * as Client from '../../src'
import * as TestClient from '../../src/testclient'
import {
  NatsTypescriptTemplateError
} from '../../src/NatsTypescriptTemplateError';
describe('v0/rust/servers/{server_id}/events/player/{steam_id}/chatted can talk to itself', () => {
  var client: Client.NatsAsyncApiClient;
  var testClient: TestClient.NatsAsyncApiTestClient;
  before(async () => {
    client = new Client.NatsAsyncApiClient();
    testClient = new TestClient.NatsAsyncApiTestClient();
    const natsHost = process.env.NATS_HOST || "0.0.0.0"
    const natsPort = process.env.NATS_PORT || "4222"
    const natsUrl = `${natsHost}:${natsPort}`
    await client.connectToHost(natsUrl);
    await testClient.connectToHost(natsUrl);
  });
  it('can send message', async () => {
    var receivedError: NatsTypescriptTemplateError | undefined = undefined;
    var receivedMsg: Client.ChatMessage | undefined = undefined;
    var receivedServerId: string | undefined = undefined;
    var receivedSteamId: string | undefined = undefined;
    var publishMessage: TestClient.ChatMessage = TestClient.ChatMessage.unmarshal({
      "steam_id": "string",
      "player_name": "string",
      "raw_message": "string",
      "full_message": "string",
      "is_admin": true,
      "rank": 0,
      "title": "string",
      "timestamp": "2016-08-29T09:12:33.001Z"
    });
    var ServerIdToSend: string = "string"
    var SteamIdToSend: string = "string"
    const subscription = await client.subscribeToV0RustServersServerIdEventsPlayerSteamIdChatted((err, msg, server_id, steam_id) => {
        receivedError = err;
        receivedMsg = msg;
        receivedServerId = server_id;
        receivedSteamId = steam_id;
      }, ServerIdToSend, SteamIdToSend,
      true
    );
    const tryAndWaitForResponse = new Promise((resolve, reject) => {
      let isReturned = false;
      setTimeout(() => {
        if (!isReturned) {
          reject(new Error("Timeout"));
        }
      }, 3000)
      setInterval(async () => {
        if (subscription.getReceived() === 1) {
          resolve(undefined);
          isReturned = true
        }
      }, 100);
    });
    await testClient.publishToV0RustServersServerIdEventsPlayerSteamIdChatted(publishMessage, ServerIdToSend, SteamIdToSend);
    await tryAndWaitForResponse;
    expect(receivedError).to.be.undefined;
    expect(receivedMsg).to.not.be.undefined;
    expect(receivedMsg!.marshal()).to.equal(publishMessage.marshal());
    expect(receivedServerId).to.be.equal(ServerIdToSend);
    expect(receivedSteamId).to.be.equal(SteamIdToSend);
  });
  after(async () => {
    await client.disconnect();
    await testClient.disconnect();
  });
});
```